### PR TITLE
Assign overrides to group

### DIFF
--- a/lua/neon/init.lua
+++ b/lua/neon/init.lua
@@ -434,7 +434,7 @@ local function set_groups()
 
     local overrides = vim.g.neon_overrides
     if overrides then
-        vim.tbl_extend("force", groups, overrides)
+        groups = vim.tbl_extend("force", groups, overrides)
     end
 
     for group, parameters in pairs(groups) do


### PR DESCRIPTION
Old code didn't assign the extended table to the `groups` var and no overrides ever worked.
When re-assigning the var to the extension of overrides and groups, we can override default highlights.